### PR TITLE
Update for Swift snapshot 04-25

### DIFF
--- a/Sources/PostgreSQL.swift
+++ b/Sources/PostgreSQL.swift
@@ -83,7 +83,7 @@ public class PSQLStatement {
     
         let res: OpaquePointer
         if let values = values where values.count > 0 {
-            let paramsValues = UnsafeMutablePointer<UnsafePointer<Int8>>.init(allocatingCapacity: values.count)
+            let paramsValues = UnsafeMutablePointer<UnsafePointer<Int8>?>.init(allocatingCapacity: values.count)
             
             var v = [[UInt8]]()
             for i in 0..<values.count {
@@ -114,11 +114,11 @@ public class PSQLStatement {
         case PGRES_BAD_RESPONSE:
             PQclear(res)
         case PGRES_NONFATAL_ERROR:
-            errorMessage = String(PQresultErrorMessage(res)) ?? ""
+			errorMessage = String(cString: PQresultErrorMessage(res)) ?? ""
             PQclear(res)
             throw PostgresSQLError.InvalidSQL(message: errorMessage)
         case PGRES_FATAL_ERROR:
-            errorMessage = String(PQresultErrorMessage(res)) ?? ""
+            errorMessage = String(cString: PQresultErrorMessage(res)) ?? ""
             PQclear(res)
             throw PostgresSQLError.InvalidSQL(message: errorMessage)
         default:
@@ -181,24 +181,24 @@ public class PSQLResult {
         PQclear(result)
     }
     
-    public func columnName(index: Int) -> String? {
+    public func columnName(_ index: Int) -> String? {
         guard let result = result else {
             return ""
         }
-        return String(PQfname(result, Int32(index)))
+		return String(cString: PQfname(result, Int32(index)))
     }
     
-    public func isNullAt(rowIndex: Int, columnIndex: Int) -> Bool {
+    public func isNullAt(_ rowIndex: Int, columnIndex: Int) -> Bool {
         guard let result = result else {
             return true
         }
         return 1 == PQgetisnull(result, Int32(rowIndex), Int32(columnIndex))
     }
     
-    public func stringAt(rowIndex: Int, columnIndex: Int) -> String {
+    public func stringAt(_ rowIndex: Int, columnIndex: Int) -> String {
         guard let result = result else {
             return ""
         }
-        return String(PQgetvalue(result, Int32(rowIndex), Int32(columnIndex))) ?? ""
+		return String(cString: PQgetvalue(result, Int32(rowIndex), Int32(columnIndex))) ?? ""
     }
 }

--- a/Sources/PostgreSQLDriver.swift
+++ b/Sources/PostgreSQLDriver.swift
@@ -30,11 +30,13 @@ public class PostgreSQLDriver: Fluent.Driver {
         try self.database.connect()
     }
 
-    public func execute<T: Model>(query: Query<T>) throws -> [[String: Value]] {
+    public func execute<T: Model>(_ query: Query<T>) throws -> [[String: Value]] {
         let sql = P_SQL(query: query)
+		let sqlStatement = sql.statement //Statement is a computed property that builds sql.values Values is empty before statement is first called
         let values: [String] = sql.values.map { return $0.string }
-        let statement = self.database.createStatement(withQuery: sql.statement, values: values)
-        
+		
+        let statement = self.database.createStatement(withQuery: sqlStatement, values: values)
+		
         do {
             let result = try statement.execute()
             return dataFromResult(result)
@@ -56,7 +58,7 @@ public class PostgreSQLDriver: Fluent.Driver {
     // MARK: - Internal
     // TODO: have return values not be just strings
     
-    internal func dataFromResult(result: PSQLResult) -> [[String: Value]] {
+    internal func dataFromResult(_ result: PSQLResult) -> [[String: Value]] {
         guard result.rowCount > 0 && result.columnCount > 0 else {
             return []
         }


### PR DESCRIPTION
This updates some syntax to work with the 04-25 Swift snapshot

Also fixes a major issue where strings (column names and values!) are created with the value of the  C String pointers returned from libpq, instead of using the cString constructor
