### PR TITLE
Add timestamp datatype

### DIFF
--- a/Sources/FluentPostgreSQL/PostgreSQLSerializer.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLSerializer.swift
@@ -31,6 +31,8 @@ public final class PostgreSQLSerializer: GeneralSQLSerializer {
             return "FLOAT"
         case .data:
             return "BYTEA"
+        case .timestamp:
+            return "TIMESTAMP"
         default:
             break
         }


### PR DESCRIPTION
Requires implementation in Fluent first. See PR [#106](https://github.com/vapor/fluent/pull/106).
