### PR TITLE
Implements count functionality to queries

### DIFF
--- a/Sources/FluentPostgreSQL/PostgreSQLDriver.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLDriver.swift
@@ -69,6 +69,13 @@ public class PostgreSQLDriver: Fluent.Driver {
                 // the results are
                 return result
             }
+        case .count:
+            // Get the first row and first column value as int
+            // (which should be the count, otherwise use 0)
+            let integer = result
+                .nodeArray?.first?
+                .nodeObject?.first?.1.int ?? 0
+            return .number(.int(integer))
         default:
             // return the results of the query
             return result


### PR DESCRIPTION
This is part of a series of pull requests to implement the count functionality for queries in Fluent. This addition allows to quickly determine the number of results of a query, without retrieving and parsing any data from the database.

There is also a pull request for Fluent (vapor/fluent#115).
