### PR TITLE
Fixed dropping table if constraints prevent it.

### DIFF
--- a/Sources/FluentPostgreSQL/PostgreSQLSerializer.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLSerializer.swift
@@ -122,4 +122,12 @@ public final class PostgreSQLSerializer: GeneralSQLSerializer {
 
         return statement.joined(separator: " ")
     }
+    
+    public override func sql(_ tableAction: SQL.TableAction, _ table: String) -> String {
+        var sql = super.sql(tableAction, table)
+        if case .drop = tableAction {
+            sql += " CASCADE"
+        }
+        return sql
+    }
 }


### PR DESCRIPTION
When trying to drop a table with constraints to others, `CASCADE` has to be used in order to really drop the table.
