### PR TITLE
Fixed schema unit test with data as [UInt8]

### DIFF
--- a/Tests/FluentPostgreSQLTests/SchemaTests.swift
+++ b/Tests/FluentPostgreSQLTests/SchemaTests.swift
@@ -109,7 +109,7 @@ class SchemaTests: XCTestCase {
             stringOptional: nil,
             double: 3.14,
             bool: false,
-            data: [0x04, 0x02]
+            data: [0x04, 0x02, 0xFF]
         )
 
         do {

--- a/Tests/FluentPostgreSQLTests/SchemaTests.swift
+++ b/Tests/FluentPostgreSQLTests/SchemaTests.swift
@@ -54,7 +54,11 @@ class SchemaTests: XCTestCase {
             stringOptional = try node.extract("string_optional")
             double = try node.extract("double")
             bool = try node.extract("bool")
-            data = try node.extract("data")
+            
+            guard let dataNode = node["data"], case .bytes(let dataBytes) = dataNode else {
+                throw NodeError.unableToConvert(node: nil, expected: "Node.bytes")
+            }
+            data = dataBytes
         }
 
         func makeNode(context: Context) throws -> Node {
@@ -66,7 +70,7 @@ class SchemaTests: XCTestCase {
                 "string_optional": stringOptional,
                 "double": double,
                 "bool": bool,
-                "data": Node(node: data)
+                "data": Node(bytes: data),
             ])
         }
 

--- a/Tests/FluentPostgreSQLTests/SchemaTests.swift
+++ b/Tests/FluentPostgreSQLTests/SchemaTests.swift
@@ -26,7 +26,7 @@ class SchemaTests: XCTestCase {
         var stringOptional: String?
         var double: Double
         var bool: Bool
-        var data: [UInt8]?
+        var data: [UInt8]
 
         init(
             int: Int,
@@ -35,7 +35,7 @@ class SchemaTests: XCTestCase {
             stringOptional: String?,
             double: Double,
             bool: Bool,
-            data: [UInt8]?
+            data: [UInt8]
         ) {
             self.int = int
             self.stringDefault = stringDefault
@@ -66,7 +66,7 @@ class SchemaTests: XCTestCase {
                 "string_optional": stringOptional,
                 "double": double,
                 "bool": bool,
-                "data": data != nil ? Node(node: data!) : Node.null
+                "data": Node(node: data)
             ])
         }
 
@@ -79,7 +79,7 @@ class SchemaTests: XCTestCase {
                 builder.string("string_optional", optional: true)
                 builder.double("double")
                 builder.bool("bool")
-                builder.data("data", optional: true)
+                builder.data("data")
             }
         }
         static func revert(_ database: Database) throws {


### PR DESCRIPTION
Fixed the schema unit test for `[UInt8]` after fixing this in vapor/postgresql#19
