### PR TITLE
move to fluent 1.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
     name: "FluentPostgreSQL",
     dependencies: [
         .Package(url: "https://github.com/vapor/postgresql.git", majorVersion: 1),
-        .Package(url: "https://github.com/vapor/fluent.git", majorVersion: 1, minor: 0)
+        .Package(url: "https://github.com/vapor/fluent.git", majorVersion: 1)
     ]
 )


### PR DESCRIPTION
This repository should depend on Fluent 1.x, not 1.0 specifically.