### PR TITLE
Fix crasher in PostreSQLSerializer when ID is not provided

### DIFF
--- a/Sources/FluentPostgreSQL/PostgreSQLSerializer.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLSerializer.swift
@@ -104,7 +104,7 @@ public final class PostgreSQLSerializer: GeneralSQLSerializer {
         // Differs from Fluent implementation
         // Removes idKey value
         // The idKey needs to be blank when inserting a record
-        if (dict["id"]?.isNull)! {
+        if dict["id"]?.isNull ?? false {
             dict.removeValue(forKey: "id")
         }
 

--- a/Tests/FluentPostgreSQLTests/SerializerTests.swift
+++ b/Tests/FluentPostgreSQLTests/SerializerTests.swift
@@ -18,10 +18,17 @@ class SerializerTests: XCTestCase {
         let serializer = PostgreSQLSerializer(sql: .insert(table: "test", data: input))
         let result = serializer.serialize()
 
-        XCTAssertEqual("INSERT INTO test (id, name) VALUES ($1, $2)", result.0)
-        XCTAssertEqual(2, result.1.count)
-        XCTAssertEqual(Node.string("foo"), result.1.first ?? Node.null)
-        XCTAssertEqual(Node.string("bar"), result.1.last ?? Node.null)
+        if "INSERT INTO test (id, name) VALUES ($1, $2)" == result.0 {
+            XCTAssertEqual(2, result.1.count)
+            XCTAssertEqual(Node.string("foo"), result.1.first ?? Node.null)
+            XCTAssertEqual(Node.string("bar"), result.1.last ?? Node.null)
+        } else if "INSERT INTO test (name, id) VALUES ($1, $2)" == result.0 {
+            XCTAssertEqual(2, result.1.count)
+            XCTAssertEqual(Node.string("bar"), result.1.first ?? Node.null)
+            XCTAssertEqual(Node.string("foo"), result.1.last ?? Node.null)
+        } else {
+            XCTFail("serialize() returned an unexpected SQL statement: \(result.0)")
+        }
     }
     
     func testSerializerInsertRemovesNullID() throws {

--- a/Tests/FluentPostgreSQLTests/SerializerTests.swift
+++ b/Tests/FluentPostgreSQLTests/SerializerTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import Node
+@testable import FluentPostgreSQL
+
+class SerializerTests: XCTestCase {
+    static let allTests = [
+        ("testSerializerInsert", testSerializerInsert),
+        ("testSerializerInsertRemovesNullID", testSerializerInsertRemovesNullID),
+        ("testSerializerInsertWorksWithoutID", testSerializerInsertWorksWithoutID),
+    ]
+
+    func testSerializerInsert() throws {
+        let input = Node.object([
+            "id": Node.string("foo"),
+            "name": Node.string("bar")
+        ])
+        
+        let serializer = PostgreSQLSerializer(sql: .insert(table: "test", data: input))
+        let result = serializer.serialize()
+
+        XCTAssertEqual("INSERT INTO test (id, name) VALUES ($1, $2)", result.0)
+        XCTAssertEqual(2, result.1.count)
+        XCTAssertEqual(Node.string("foo"), result.1.first ?? Node.null)
+        XCTAssertEqual(Node.string("bar"), result.1.last ?? Node.null)
+    }
+    
+    func testSerializerInsertRemovesNullID() throws {
+        let input = Node.object([
+            "id": Node.null,
+            "name": Node.string("bar")
+        ])
+
+        let serializer = PostgreSQLSerializer(sql: .insert(table: "test", data: input))
+        let result = serializer.serialize()
+        
+        XCTAssertEqual("INSERT INTO test (name) VALUES ($1)", result.0)
+        XCTAssertEqual(1, result.1.count)
+        XCTAssertEqual(Node.string("bar"), result.1.first ?? Node.null)
+    }
+    
+    func testSerializerInsertWorksWithoutID() throws {
+        let input = Node.object([
+            "name": Node.string("bar")
+        ])
+
+        let serializer = PostgreSQLSerializer(sql: .insert(table: "test", data: input))
+        let result = serializer.serialize()
+        
+        XCTAssertEqual("INSERT INTO test (name) VALUES ($1)", result.0)
+        XCTAssertEqual(1, result.1.count)
+        XCTAssertEqual(Node.string("bar"), result.1.first ?? Node.null)
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -7,6 +7,7 @@ XCTMain([
     testCase(DriverTests.allTests),
     testCase(JoinTests.allTests),
     testCase(SchemaTests.allTests),
+    testCase(SerializerTests.allTests)
 ])
 
 #endif


### PR DESCRIPTION
This PR adds some basic tests for PostgreSQLSerializer's output, and resolves #19 by replacing the force unwrap with safe and sane nil-coalescing.