### PR TITLE
Changes required for generalising the field type used for DataType.id from int

### DIFF
--- a/Sources/FluentPostgreSQL/PostgreSQLDriver.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLDriver.swift
@@ -70,11 +70,11 @@ public class PostgreSQLDriver: Fluent.Driver {
                 // When receiving a invalidSQL error, there is basically no LASTVAL, so ignore.
             }
             
-            // return the value of the 'id' field from the successfully inserted record 
+            // return the value against the primary key from the successfully inserted record
             // if we failed to get it via LASTVAL above (which would fail at least for non-integral primary keys).
             switch query.sql {
             case .insert(_, let data):
-                if let id = data?["id"] {
+                if let id = data?[self.idKey] {
                     return id
                 }
             default: ()

--- a/Sources/FluentPostgreSQL/PostgreSQLDriver.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLDriver.swift
@@ -69,7 +69,16 @@ public class PostgreSQLDriver: Fluent.Driver {
             catch PostgreSQL.DatabaseError.invalidSQL(message: _) {
                 // When receiving a invalidSQL error, there is basically no LASTVAL, so ignore.
             }
-
+            
+            // return the value of the 'id' field from the successfully inserted record 
+            // if we failed to get it via LASTVAL above (which would fail at least for non-integral primary keys).
+            switch query.sql {
+            case .insert(_, let data):
+                if let id = data?["id"] {
+                    return id
+                }
+            default: ()
+            }
             // no id found, return whatever
             // the results are
             return result

--- a/Sources/FluentPostgreSQL/PostgreSQLSerializer.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLSerializer.swift
@@ -19,14 +19,19 @@ public final class PostgreSQLSerializer: GeneralSQLSerializer {
 
     public override func sql(_ type: Schema.Field.DataType) -> String {
         switch type {
-        case .id:
-            return "SERIAL PRIMARY KEY"
-        case .string(let length):
-            if let length = length {
-                return "VARCHAR(\(length))"
-            } else {
-                return "VARCHAR(255)"
+        case .id(let keyType):
+            switch keyType ?? Schema.Field.KeyType.int {
+            case .int:
+                return "SERIAL PRIMARY KEY"
+                
+            case .string(let length):
+                return "VARCHAR(\(length ?? 255)) PRIMARY KEY"
+                
+            case .custom(let customType):
+                return "\(customType) PRIMARY KEY"
             }
+        case .string(let length):
+            return "VARCHAR(\(length ?? 255))"
         case .double:
             return "FLOAT"
         case .data:


### PR DESCRIPTION
This PR contains associated changes to https://github.com/vapor/fluent/pull/165, in order to generalise the field type used to represent `DataType.id`.

In addition, these changes fix an associated problem when using any non-string value with the field name matching driver's `idKey` – the `SELECT LASTVAL()` which assumes an integral value. Unrelated to the goals of this PR, there as far as I understand remains a problem using `SELECT LASTVAL()` here with potential race conditions because no transaction is created around inserting a record and reading the last value. Perhaps should be filed as a separate issue in this repo?