### PR TITLE
Fixes an issue with the driver failing to return inserted ID when inserting record with a string typed ID

### DIFF
--- a/Sources/FluentPostgreSQL/PostgreSQLDriver.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLDriver.swift
@@ -3,7 +3,7 @@ import PostgreSQL
 
 public class PostgreSQLDriver: Fluent.Driver {
     
-    public static var idKey: String = "id"
+    internal static let idKey: String = "id"
     public var idKey: String = PostgreSQLDriver.idKey
     public var database: PostgreSQL.Database
 

--- a/Sources/FluentPostgreSQL/PostgreSQLDriver.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLDriver.swift
@@ -2,7 +2,9 @@ import Fluent
 import PostgreSQL
 
 public class PostgreSQLDriver: Fluent.Driver {
-    public var idKey: String = "id"
+    
+    public static var idKey: String = "id"
+    public var idKey: String = PostgreSQLDriver.idKey
     public var database: PostgreSQL.Database
 
     /**
@@ -56,23 +58,7 @@ public class PostgreSQLDriver: Fluent.Driver {
 
         switch query.action {
         case .create:
-            // fetch the last inserted value
-            do {
-                let lastval = try _execute("SELECT LASTVAL();", [], connection)
-                // check if it contains an id
-                if let id = lastval[0, "lastval"]?.int {
-                    // return the id to fluent to
-                    // be the model's new id
-                    return .number(.int(id))
-                }
-            }
-            catch PostgreSQL.DatabaseError.invalidSQL(message: _) {
-                // When receiving a invalidSQL error, there is basically no LASTVAL, so ignore.
-            }
-
-            // no id found, return whatever
-            // the results are
-            return result
+            return (result[idKey]?.array as? [Node])?.first ?? result
         default:
             // return the results of the query
             return result

--- a/Sources/FluentPostgreSQL/PostgreSQLDriver.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLDriver.swift
@@ -4,7 +4,7 @@ import PostgreSQL
 public class PostgreSQLDriver: Fluent.Driver {
     
     internal static let idKey: String = "id"
-    public var idKey: String = PostgreSQLDriver.idKey
+    public let idKey: String = PostgreSQLDriver.idKey
     public var database: PostgreSQL.Database
 
     /**
@@ -58,7 +58,7 @@ public class PostgreSQLDriver: Fluent.Driver {
 
         switch query.action {
         case .create:
-            return (result[idKey]?.array as? [Node])?.first ?? result
+            return result[idKey]?.nodeArray?.first ?? result
         default:
             // return the results of the query
             return result

--- a/Sources/FluentPostgreSQL/PostgreSQLSerializer.swift
+++ b/Sources/FluentPostgreSQL/PostgreSQLSerializer.swift
@@ -2,10 +2,18 @@ import Fluent
 
 public final class PostgreSQLSerializer: GeneralSQLSerializer {
     var positionalParameter: Int = 0
-
+    
     public override func serialize() -> (String, [Node]) {
         self.positionalParameter = 0
-        return super.serialize()
+        
+        let serialized = super.serialize()
+        
+        switch sql {
+        case .insert:
+            return (serialized.0 + " RETURNING \(PostgreSQLDriver.idKey)", serialized.1)
+        default:
+            return serialized
+        }
     }
 
     public override func sql(_ value: Node) -> String {

--- a/Tests/FluentPostgreSQLTests/SerializerTests.swift
+++ b/Tests/FluentPostgreSQLTests/SerializerTests.swift
@@ -18,11 +18,11 @@ class SerializerTests: XCTestCase {
         let serializer = PostgreSQLSerializer(sql: .insert(table: "test", data: input))
         let result = serializer.serialize()
 
-        if "INSERT INTO test (id, name) VALUES ($1, $2)" == result.0 {
+        if result.0.hasPrefix("INSERT INTO test (id, name) VALUES ($1, $2)") {
             XCTAssertEqual(2, result.1.count)
             XCTAssertEqual(Node.string("foo"), result.1.first ?? Node.null)
             XCTAssertEqual(Node.string("bar"), result.1.last ?? Node.null)
-        } else if "INSERT INTO test (name, id) VALUES ($1, $2)" == result.0 {
+        } else if result.0.hasPrefix("INSERT INTO test (name, id) VALUES ($1, $2)") {
             XCTAssertEqual(2, result.1.count)
             XCTAssertEqual(Node.string("bar"), result.1.first ?? Node.null)
             XCTAssertEqual(Node.string("foo"), result.1.last ?? Node.null)
@@ -40,7 +40,8 @@ class SerializerTests: XCTestCase {
         let serializer = PostgreSQLSerializer(sql: .insert(table: "test", data: input))
         let result = serializer.serialize()
         
-        XCTAssertEqual("INSERT INTO test (name) VALUES ($1)", result.0)
+        XCTAssertTrue(result.0.hasPrefix("INSERT INTO test (name) VALUES ($1)"),
+                      "Unexpected serialized query string: '\(result.0)'")
         XCTAssertEqual(1, result.1.count)
         XCTAssertEqual(Node.string("bar"), result.1.first ?? Node.null)
     }
@@ -53,7 +54,8 @@ class SerializerTests: XCTestCase {
         let serializer = PostgreSQLSerializer(sql: .insert(table: "test", data: input))
         let result = serializer.serialize()
         
-        XCTAssertEqual("INSERT INTO test (name) VALUES ($1)", result.0)
+        XCTAssertTrue(result.0.hasPrefix("INSERT INTO test (name) VALUES ($1)"),
+                      "Unexpected serialized query string: '\(result.0)'")
         XCTAssertEqual(1, result.1.count)
         XCTAssertEqual(Node.string("bar"), result.1.first ?? Node.null)
     }


### PR DESCRIPTION
This PR fixes an issue with the driver failing to return inserted ID when inserting record with a string typed ID, an issue which appears specific to PostgreSQL (or at least it is not apparently happening with MySQL). The reason for the symptoms is that `SELECT LASTVAL();` does not work for non-integral primary key types. Tests were added to cover the case. 

Note that the issue would not manifest itself prior to this change when using `save()`, but only with the `entity.query().create(Node(…))` route of saving, which the PostgreSQL provider happens to go through, therefore exposing anyone using for example the Vapor RESTful resources along with string typed IDs with PostgreSQL to the bug that this PR fixes.

This PR partially addresses https://github.com/vapor/postgresql-driver/issues/17 in that one can create string typed IDs with `table.custom("id", type: "char(36) primary key")` (thanks @tannernelson), but you're of course hard coding your database backend dependency and cannot take use of the `.id` type yet.

NOTE! There remains a blatant race condition in the implementation for retrieving the inserted ID for the `.create` action of `Query` through the use of `SELECT LASTVAL();` still, as the record creation and `SELECT LASTVAL();` are not wrapped in a transaction.