### PR TITLE
Testing improvements and BYTEA issue reproduction

### DIFF
--- a/Tests/PostgreSQLDriverTests/FluentPostgreSQLTests.swift
+++ b/Tests/PostgreSQLDriverTests/FluentPostgreSQLTests.swift
@@ -66,7 +66,8 @@ class FluentPostgreSQLTests: XCTestCase {
 
             try Photo.prepare(database)
 
-            let randomData = try OSRandom.bytes(count: 100)
+            // harder test: try OSRandom.bytes(count: 10_000_000)
+            let randomData: [UInt8] = [48, 49, 50, 51, 52]
 
             let photo = Photo(title: "The Treachery of Images", content: randomData)
             try photo.save()

--- a/Tests/PostgreSQLDriverTests/FluentPostgreSQLTests.swift
+++ b/Tests/PostgreSQLDriverTests/FluentPostgreSQLTests.swift
@@ -46,11 +46,12 @@ class FluentPostgreSQLTests: XCTestCase {
             try! database.delete(Atom.self)
         }
         
+        let id = UUID()
         try Atom.prepare(database)
-        let atom = Atom(id: Identifier(5), name: "Test", protons: 3, weight: 1.5)
+        let atom = Atom(id: Identifier(id.uuidString), name: "Test", protons: 3, weight: 1.5)
         try atom.save()
         
-        XCTAssertNotNil(try Atom.makeQuery().find(5))
+        XCTAssertNotNil(try Atom.makeQuery().find(id))
     }
 
     static let allTests = [

--- a/Tests/PostgreSQLDriverTests/Photo.swift
+++ b/Tests/PostgreSQLDriverTests/Photo.swift
@@ -1,0 +1,37 @@
+import Fluent
+
+class Photo: Entity, Preparation {
+    public let storage = Storage()
+    var title: String?
+    var content: [UInt8]
+    
+    init(id: Identifier? = nil, title: String?, content: [UInt8]) {
+        self.title = title
+        self.content = content
+        self.id = id
+    }
+
+    required init(row: Row) throws {
+        title = try row.get("title")
+        content = try row.get("content")
+    }
+
+    func makeRow() throws -> Row {
+        var row = Row()
+        try row.set("title", title)
+        try row.set("content", content)
+        return row
+    }
+    
+    static func prepare(_ database: Database) throws {
+        try database.create(self) { photos in
+            photos.id()
+            photos.string("title", optional: true)
+            photos.bytes("content")
+        }
+    }
+    
+    static func revert(_ database: Database) throws {
+        try database.delete(self)
+    }
+}

--- a/Tests/PostgreSQLDriverTests/Photo.swift
+++ b/Tests/PostgreSQLDriverTests/Photo.swift
@@ -19,7 +19,7 @@ class Photo: Entity, Preparation {
     func makeRow() throws -> Row {
         var row = Row()
         try row.set("title", title)
-        try row.set("content", content)
+        try row.set("content", StructuredData.bytes(content))
         return row
     }
     

--- a/Tests/PostgreSQLDriverTests/Photo.swift
+++ b/Tests/PostgreSQLDriverTests/Photo.swift
@@ -13,7 +13,7 @@ class Photo: Entity, Preparation {
 
     required init(row: Row) throws {
         title = try row.get("title")
-        content = try row.get("content")
+        content = row["content"]?.bytes ?? []
     }
 
     func makeRow() throws -> Row {


### PR DESCRIPTION
This PR adds a test for saving and retrieving a byte array via Fluent.
Possibly related to vapor-community/postgresql#45.

Currently the new test fails with the following assert:

```
XCTAssertEqual failed: ("[48, 49, 50, 51, 52]") is not equal to ("[123, 52, 56, 44, 52, 57, 44, 53, 48, 44, 53, 49, 44, 53, 50, 125]") - Binary content did not match
```

The received value is actually the UTF-8 encoded version of the string `{48,49,50,51,52}`.
The database contains this data in the content column: `\x7b34382c34392c35302c35312c35327d` (which is the incorrect string, hex encoded).