### PR TITLE
Fall back to counting id instead of *

### DIFF
--- a/Sources/PostgreSQLDriver/PostgreSQLSerializer.swift
+++ b/Sources/PostgreSQLDriver/PostgreSQLSerializer.swift
@@ -6,7 +6,12 @@ public final class PostgreSQLSerializer<E: Entity>: GeneralSQLSerializer<E> {
 
     public override func serialize() -> (String, [Node]) {
         positionalIndex = 0
-        return super.serialize()
+        switch query.action {
+        case .aggregate(let field, let agg):
+            return aggregate(field ?? E.idKey, agg)
+        default:
+            return super.serialize()
+        }
     }
     
     // MARK: Data


### PR DESCRIPTION
I'm overriding `GeneralSQLSerializer.serialize()` to avoid it falling back to `*` when no field is provided for aggregate queries.
`COUNT (DISTINCT *)` is not valid PSQL syntax even though it's correct in MySQL and SQLite. In PSQL the correct way to do a distinct count is to count a field or group of fields.
The only field we can safely assume is present is `id`, so that's what I'm counting now.